### PR TITLE
dict: fix string key length

### DIFF
--- a/dbus.c
+++ b/dbus.c
@@ -1567,7 +1567,7 @@ static zval *php_dbus_to_zval(DBusMessageIter *args, zval **key TSRMLS_DC)
 						}
 
 						if (val && Z_TYPE_P(new_key) == IS_STRING) {
-							add_assoc_zval_ex(dictobj->elements, Z_STRVAL_P(new_key), Z_STRLEN_P(new_key) + 1, val);
+							add_assoc_zval_ex(dictobj->elements, Z_STRVAL_P(new_key), Z_STRLEN_P(new_key), val);
 						} else if (val && Z_TYPE_P(new_key) == IS_LONG) {
 							add_index_zval(dictobj->elements, Z_LVAL_P(new_key), val);
 						}


### PR DESCRIPTION
with php 7.x, returned strings were null terminated

test case:
```
<?php
  $connection = new DBus(DBus::BUS_SYSTEM, true);
  $proxy = $connection->createProxy("me.burnaway.BrandMeister.N2841", "/me/burnaway/BrandMeister", "me.burnaway.BrandMeister");
  print json_encode($proxy->getLinkInformation("MMDVM Host")) . "\n";
?>
```

before:
```
{"dict":{"Port\u0000":{"variant":62031}}}
```

after:
```
{"dict":{"Port":{"variant":62031}}}
```

@derickr let me know if you want me to bump PHP_DBUS_VERSION