### PR TITLE
Add support for setting method call timeout

### DIFF
--- a/examples/set-timeout.php
+++ b/examples/set-timeout.php
@@ -1,0 +1,8 @@
+<?php
+$d = new Dbus;
+$d->setDefaultTimeout( 10 * 1000 );
+$n = $d->createProxy( "im.pidgin.purple.PurpleService", "/im/pidgin/purple/PurpleObject", "org.freedesktop.DBus.Introspectable");
+$d = $n->Introspect( false );
+echo $d[0];die();
+file_put_contents( 'introspect.xml', $d[0] );
+?>

--- a/php_dbus.h
+++ b/php_dbus.h
@@ -158,6 +158,7 @@ PHP_METHOD(Dbus, waitLoop);
 PHP_METHOD(Dbus, requestName);
 PHP_METHOD(Dbus, registerObject);
 PHP_METHOD(Dbus, createProxy);
+PHP_METHOD(Dbus, setDefaultTimeout);
 
 PHP_METHOD(DbusObject, __construct);
 PHP_METHOD(DbusObject, __call);


### PR DESCRIPTION
**Thorough review would be appreciated**. This is the first time I'm working on a PHP extension. I already had some "fun" with memory corruption because I added the new variable at the end of `php_dbus_obj` at first, not realising there's some magic going on with `zend_object`.

For some D-Bus services the default D-Bus timeout (25s) may not be enough; conversely for some applications the default timeout may be much longer than they'd like to wait.

Add support for setting the timeout to use for method invocations globally. At least for PHP < 8 this is probably the best we can do as there is no way to pass additional timeout information to individual method calls: we cannot reliably tell whether a positional parameter (to `__call()`) is the optional timeout or a parameter for the D-Bus method to invoke.

For PHP 8+ it may be possible to use named arguments to pass a per-invocation timeout parameter but that's left for the future as I cannot test it.