### PR TITLE
php8.4: update API usage to replace rebuild_object_properties

### DIFF
--- a/php_dbus.h
+++ b/php_dbus.h
@@ -49,7 +49,7 @@
 # define DBUS_ZEND_OBJECT_PROPERTIES_INIT(_objPtr, _ce) \
     object_properties_init(&_objPtr->std, _ce); \
     if (!_objPtr->std.properties) { \
-        rebuild_object_properties(&_objPtr->std); \
+        zend_std_get_properties_ex(&_objPtr->std); \
     };
 
 # define DBUS_ZEND_OBJECT_ALLOC(_objPtr, _ce) \


### PR DESCRIPTION
pecl-dbus build currently fails with PHP8.2 on the following error:

In file included from
/home/alexis/src/buildroot/php/build/php-pecl-dbus-aa505e4dc1063ec6aca2ab43c07b60b3b5626e1f/dbus.c:27: /home/alexis/src/buildroot/php/build/php-pecl-dbus-aa505e4dc1063ec6aca2ab43c07b60b3b5626e1f/dbus.c: In function ‘dbus_object_new_dbus_ex’:
/home/alexis/src/buildroot/php/build/php-pecl-dbus-aa505e4dc1063ec6aca2ab43c07b60b3b5626e1f/php_dbus.h:52:9: error: implicit declaration of function ‘rebuild_object_properties’; did you mean ‘rebuild_object_properties_internal’?
[-Wimplicit-function-declaration]
   52 |         rebuild_object_properties(&_objPtr->std); \

The failure is due to commit 1fbb6665458c ("Use
zend_std_build_properties() to access zend_object.properties") that has removed rebuild_object_properties. The object access has been simplified with the introduction of zend_std_get_properties_ex which automatically performs the object properties rebuild at access time if needed.

Update DBUS_ZEND_OBJECT_PROPERTIES_INIT with the new API. Make the update conservative, and so preserve php-dbus current behavior (ie forcing properties rebuild at object creation time). I guess a good next step would be to get rid of this zend_std_get_properties_ex in the init macro, as its true purpose is to actually perform a "lazy" rebuild, ie on the first access.

The commit fixes the build issues mentioned in https://github.com/derickr/pecl-dbus/pull/13#issuecomment-3175837244